### PR TITLE
Decrypt issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,11 +235,30 @@ It provides generators and library templates for supporting multiple languages a
 
 The **client-encryption-python** library provides a method you can use to integrate the OpenAPI generated client with this library:
 ```python
-from client_encryption.field_level_encryption_config import FieldLevelEncryptionConfig
 from client_encryption.api_encryption import add_encryption_layer
+
+config = {
+  "paths": {
+    "$": {
+      ...
+    }
+  },
+  "ivFieldName": "iv",
+  "encryptedKeyFieldName": "encryptedKey",
+  ...
+  "oaepPaddingDigestAlgorithm": "SHA256"
+}
 
 add_encryption_layer(api_client, config)
 ```
+
+Alternatively you can pass the configuration by a json file:
+```python
+from client_encryption.api_encryption import add_encryption_layer
+
+add_encryption_layer(api_client, "path/to/my/config.json")
+```
+
 This method will add the field level encryption in the generated OpenApi client, taking care of encrypting request and decrypting response payloads, but also of updating HTTP headers when needed, automatically, without manually calling `encrypt_payload()`/`decrypt_payload()` functions for each API request or response.
 
 ##### OpenAPI Generator <a name="openapi-generator"></a>
@@ -265,7 +284,6 @@ To use it:
 2. Import the **mastercard-client-encryption** module and the generated swagger ApiClient
 
    ```python
-   from client_encryption.field_level_encryption_config import FieldLevelEncryptionConfig
    from client_encryption.api_encryption import add_encryption_layer
    from swagger_client.api_client import ApiClient # import generated swagger ApiClient
    ```
@@ -273,13 +291,10 @@ To use it:
 3. Add the field level encryption layer to the generated client:
 
    ```python
-   # Read the service configuration file
-   config_file_path = "./config.json"
-   config = FieldLevelEncryptionConfig(config_file_path) 
    # Create a new instance of the generated client
    api_client = ApiClient()
    # Enable field level encryption
-   add_encryption_layer(api_client, config)
+   add_encryption_layer(api_client, "path/to/my/config.json")
    ```
 
 4. Use the `ApiClient` instance with the Field Level Encryption enabled:
@@ -308,7 +323,6 @@ According to the above the signing layer must be applied first in order to work 
 
    ```python
    from oauth1.signer_interceptor import add_signing_layer
-   from client_encryption.field_level_encryption_config import FieldLevelEncryptionConfig
    from client_encryption.api_encryption import add_encryption_layer
    from swagger_client.api_client import ApiClient # import generated swagger ApiClient
    ```
@@ -324,12 +338,7 @@ According to the above the signing layer must be applied first in order to work 
      
 4. Then add the field level encryption layer:
    ```python
-   # Read the service configuration file
-   config_file_path = "./config.json"
-   config = FieldLevelEncryptionConfig(config_file_path) 
-
-   # Enable field level encryption
-   add_encryption_layer(api_client, config)
+   add_encryption_layer(api_client, "path/to/my/config.json")
    ```
 
 5. Use the `ApiClient` instance with Authentication and Field Level Encryption both enabled:

--- a/client_encryption/api_encryption.py
+++ b/client_encryption/api_encryption.py
@@ -25,7 +25,7 @@ class ApiEncryption(object):
             """Wrap call_api and add field encryption layer to it."""
 
             in_body = kwargs.get("body", None)
-            kwargs["body"] = self._encrypt_payload(kwargs.get("headers", None), in_body) if in_body else in_body
+            kwargs["body"] = self._encrypt_payload(kwargs.get("header_params", None), in_body) if in_body else in_body
             kwargs["_preload_content"] = False
 
             response = func(*args, **kwargs)
@@ -95,9 +95,7 @@ def add_encryption_layer(api_client, encryption_conf_file):
 
 def __check_oauth(api_client):
     try:
-        oauth_layer = getattr(api_client.request, "__wrapped__").__oauth__
-        if not oauth_layer or type(oauth_layer) is not bool:
-            __oauth_warn()
+        api_client.request.__wrapped__
     except AttributeError:
         __oauth_warn()
 

--- a/client_encryption/api_encryption.py
+++ b/client_encryption/api_encryption.py
@@ -79,7 +79,7 @@ class ApiEncryption(object):
                 return body
 
         decrypted_body = decrypt_payload(body, conf, params)
-        payload = json.dumps(decrypted_body, indent=4).encode('utf-8')
+        payload = json.dumps(decrypted_body).encode('utf-8')
 
         return payload
 

--- a/client_encryption/encryption_utils.py
+++ b/client_encryption/encryption_utils.py
@@ -54,15 +54,21 @@ def __get_crypto_file_type(file_content):
         return FILETYPE_ASN1
 
 
-def load_hash_algorithm(algo_str):
-    """Load a hash algorithm object of Crypto.Hash from a list of supported ones."""
+def validate_hash_algorithm(algo_str):
+    """Validate a hash algorithm against a list of supported ones."""
 
     if algo_str:
         algo_key = algo_str.replace("-", "").upper()
 
         if algo_key in _SUPPORTED_HASH:
-            return _SUPPORTED_HASH[algo_key]
+            return algo_key
         else:
             raise HashAlgorithmError("Hash algorithm invalid or not supported.")
     else:
         raise HashAlgorithmError("No hash algorithm provided.")
+
+
+def load_hash_algorithm(algo_str):
+    """Load a hash algorithm object of Crypto.Hash from a list of supported ones."""
+
+    return _SUPPORTED_HASH[validate_hash_algorithm(algo_str)]

--- a/client_encryption/field_level_encryption.py
+++ b/client_encryption/field_level_encryption.py
@@ -12,10 +12,10 @@ def encrypt_payload(payload, config, _params=None):
     """Encrypt some fields of a JSON payload using the given configuration."""
 
     try:
-        if type(payload) is str:
-            json_payload = json.loads(payload)
-        else:
+        if type(payload) is dict:
             json_payload = copy.deepcopy(payload)
+        else:
+            json_payload = json.loads(payload)
 
         for elem, target in config.paths["$"].to_encrypt.items():
             if not _params:
@@ -50,10 +50,10 @@ def decrypt_payload(payload, config, _params=None):
     """Decrypt some fields of a JSON payload using the given configuration."""
 
     try:
-        if type(payload) is str:
-            json_payload = json.loads(payload)
-        else:
+        if type(payload) is dict:
             json_payload = payload
+        else:
+            json_payload = json.loads(payload)
 
         for elem, target in config.paths["$"].to_decrypt.items():
             try:

--- a/client_encryption/field_level_encryption.py
+++ b/client_encryption/field_level_encryption.py
@@ -53,7 +53,10 @@ def decrypt_payload(payload, config, _params=None):
         if type(payload) is dict:
             json_payload = payload
         else:
-            json_payload = json.loads(payload)
+            try:
+                json_payload = json.loads(payload)
+            except json.JSONDecodeError:  # not a json response - return it as is
+                return payload
 
         for elem, target in config.paths["$"].to_decrypt.items():
             try:
@@ -90,7 +93,7 @@ def decrypt_payload(payload, config, _params=None):
         return json_payload
 
     except (IOError, ValueError, TypeError) as e:
-        raise EncryptionError("Payload encryption failed!", e)
+        raise EncryptionError("Payload decryption failed!", e)
 
 
 def _encrypt_value(_key, iv, node_str):

--- a/client_encryption/field_level_encryption_config.py
+++ b/client_encryption/field_level_encryption_config.py
@@ -2,7 +2,7 @@ import json
 from OpenSSL.crypto import dump_certificate, FILETYPE_ASN1, dump_publickey
 from Crypto.Hash import SHA256
 from client_encryption.encoding_utils import Encoding
-from client_encryption.encryption_utils import load_encryption_certificate, load_decryption_key, load_hash_algorithm
+from client_encryption.encryption_utils import load_encryption_certificate, load_decryption_key, validate_hash_algorithm
 
 
 class FieldLevelEncryptionConfig(object):
@@ -44,9 +44,7 @@ class FieldLevelEncryptionConfig(object):
         else:
             self._decryption_key = None
 
-        digest_algo = json_config["oaepPaddingDigestAlgorithm"]
-        if load_hash_algorithm(digest_algo) is not None:
-            self._oaep_padding_digest_algorithm = digest_algo
+        self._oaep_padding_digest_algorithm = validate_hash_algorithm(json_config["oaepPaddingDigestAlgorithm"])
 
         data_enc = Encoding(json_config["dataEncoding"].upper())
         self._data_encoding = data_enc

--- a/client_encryption/session_key_params.py
+++ b/client_encryption/session_key_params.py
@@ -1,6 +1,6 @@
 from binascii import Error
 from Crypto.Cipher import PKCS1_OAEP, AES
-from Crypto import Random
+from Crypto.Random import get_random_bytes
 from Crypto.PublicKey import RSA
 from client_encryption.encoding_utils import encode_bytes, decode_value
 from client_encryption.encryption_utils import load_hash_algorithm
@@ -62,11 +62,11 @@ class SessionKeyParams(object):
         encoding = config.data_encoding
 
         # Generate a random IV
-        iv = Random.new().read(SessionKeyParams._BLOCK_SIZE)
+        iv = get_random_bytes(SessionKeyParams._BLOCK_SIZE)
         iv_encoded = encode_bytes(iv, encoding)
 
         # Generate an AES secret key
-        secret_key = Random.new().read(SessionKeyParams._KEY_SIZE)
+        secret_key = get_random_bytes(SessionKeyParams._KEY_SIZE)
 
         # Encrypt the secret key
         secret_key_encrypted = SessionKeyParams.__wrap_secret_key(secret_key, config)

--- a/client_encryption/version.py
+++ b/client_encryption/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__version__ = "1.0.2"
+__version__ = "1.0.3-dev"

--- a/client_encryption/version.py
+++ b/client_encryption/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__version__ = "1.0.3-dev"
+__version__ = "1.1.0"

--- a/tests/test_api_encryption.py
+++ b/tests/test_api_encryption.py
@@ -170,10 +170,9 @@ class ApiEncryptionTest(unittest.TestCase):
             }
         }, headers={"Content-Type": "application/json"})
 
-        self.assertIn("data", response.data)
-        self.assertIn("secret", response.data["data"])
-        self.assertEqual(secret2-secret1, response.data["data"]["secret"])
-        self.assertDictEqual({"Content-Type": "application/json"}, response.getheaders())
+        self.assertIn("data", response)
+        self.assertIn("secret", response["data"])
+        self.assertEqual(secret2-secret1, response["data"]["secret"])
 
     def test_add_encryption_layer_delete(self):
         secret1 = 394
@@ -187,18 +186,16 @@ class ApiEncryptionTest(unittest.TestCase):
             }
         }, headers={"Content-Type": "application/json"})
 
-        self.assertEqual("OK", response.data)
-        self.assertDictEqual({"Content-Type": "application/json"}, response.getheaders())
+        self.assertEqual("OK", response)
 
     def test_add_encryption_layer_get(self):
         test_client = MockApiClient()
         to_test.add_encryption_layer(test_client, self._json_config)
         response = MockService(test_client).do_something_get(headers={"Content-Type": "application/json"})
 
-        self.assertIn("data", response.data)
-        self.assertIn("secret", response.data["data"])
-        self.assertEqual([53, 84, 75], response.data["data"]["secret"])
-        self.assertDictEqual({"Content-Type": "application/json"}, response.getheaders())
+        self.assertIn("data", response)
+        self.assertIn("secret", response["data"])
+        self.assertEqual([53, 84, 75], response["data"]["secret"])
 
     def test_add_header_encryption_layer_post_no_oaep_algo(self):
         self._set_header_params_config()
@@ -216,10 +213,9 @@ class ApiEncryptionTest(unittest.TestCase):
             "encryptedData": {}
         }, headers={"Content-Type": "application/json"})
 
-        self.assertIn("data", response.data)
-        self.assertIn("secret", response.data["data"])
-        self.assertEqual(secret2-secret1, response.data["data"]["secret"])
-        self.assertDictEqual({"Content-Type": "application/json", "x-oaep-digest": "SHA256"}, response.getheaders())
+        self.assertIn("data", response)
+        self.assertIn("secret", response["data"])
+        self.assertEqual(secret2-secret1, response["data"]["secret"])
 
     def test_add_header_encryption_layer_post_no_cert_fingerprint(self):
         self._set_header_params_config()
@@ -237,10 +233,9 @@ class ApiEncryptionTest(unittest.TestCase):
             "encryptedData": {}
         }, headers={"Content-Type": "application/json"})
 
-        self.assertIn("data", response.data)
-        self.assertIn("secret", response.data["data"])
-        self.assertEqual(secret2-secret1, response.data["data"]["secret"])
-        self.assertDictEqual({"Content-Type": "application/json"}, response.getheaders())
+        self.assertIn("data", response)
+        self.assertIn("secret", response["data"])
+        self.assertEqual(secret2-secret1, response["data"]["secret"])
 
     def test_add_header_encryption_layer_post_no_pubkey_fingerprint(self):
         self._set_header_params_config()
@@ -258,10 +253,9 @@ class ApiEncryptionTest(unittest.TestCase):
             "encryptedData": {}
         }, headers={"Content-Type": "application/json"})
 
-        self.assertIn("data", response.data)
-        self.assertIn("secret", response.data["data"])
-        self.assertEqual(secret2-secret1, response.data["data"]["secret"])
-        self.assertDictEqual({"Content-Type": "application/json"}, response.getheaders())
+        self.assertIn("data", response)
+        self.assertIn("secret", response["data"])
+        self.assertEqual(secret2-secret1, response["data"]["secret"])
 
     def test_add_header_encryption_layer_no_iv(self):
         self._set_header_params_config()
@@ -294,10 +288,9 @@ class ApiEncryptionTest(unittest.TestCase):
             "encryptedData": {}
         }, headers={"Content-Type": "application/json"})
 
-        self.assertIn("data", response.data)
-        self.assertIn("secret", response.data["data"])
-        self.assertEqual(secret2-secret1, response.data["data"]["secret"])
-        self.assertDictEqual({"Content-Type": "application/json"}, response.getheaders())
+        self.assertIn("data", response)
+        self.assertIn("secret", response["data"])
+        self.assertEqual(secret2-secret1, response["data"]["secret"])
 
     def test_add_header_encryption_layer_delete(self):
         self._set_header_params_config()
@@ -314,8 +307,7 @@ class ApiEncryptionTest(unittest.TestCase):
             "encryptedData": {}
         }, headers={"Content-Type": "application/json"})
 
-        self.assertEqual("OK", response.data)
-        self.assertDictEqual({"Content-Type": "application/json"}, response.getheaders())
+        self.assertEqual("OK", response)
 
     def test_add_header_encryption_layer_get(self):
         self._set_header_params_config()
@@ -324,10 +316,9 @@ class ApiEncryptionTest(unittest.TestCase):
         to_test.add_encryption_layer(test_client, self._json_config)
         response = MockService(test_client).do_something_get_use_headers(headers={"Content-Type": "application/json"})
 
-        self.assertIn("data", response.data)
-        self.assertIn("secret", response.data["data"])
-        self.assertEqual([53, 84, 75], response.data["data"]["secret"])
-        self.assertDictEqual({"Content-Type": "application/json"}, response.getheaders())
+        self.assertIn("data", response)
+        self.assertIn("secret", response["data"])
+        self.assertEqual([53, 84, 75], response["data"]["secret"])
 
     @patch('client_encryption.api_encryption.__oauth_warn')
     def test_add_encryption_layer_oauth_set(self, __oauth_warn):

--- a/tests/test_api_encryption.py
+++ b/tests/test_api_encryption.py
@@ -62,14 +62,14 @@ class ApiEncryptionTest(unittest.TestCase):
 
         test_headers = {"Content-Type": "application/json"}
 
-        decrypted = api_encryption._decrypt_payload(body={
+        decrypted = json.loads(api_encryption._decrypt_payload(body={
             "encryptedData": {
                 "iv": "uldLBySPY3VrznePihFYGQ==",
                 "encryptedKey": "Jmh/bQPScUVFHSC9qinMGZ4lM7uetzUXcuMdEpC5g4C0Pb9HuaM3zC7K/509n7RTBZUPEzgsWtgi7m33nhpXsUo8WMcQkBIZlKn3ce+WRyZpZxcYtVoPqNn3benhcv7cq7yH1ktamUiZ5Dq7Ga+oQCaQEsOXtbGNS6vA5Bwa1pjbmMiRIbvlstInz8XTw8h/T0yLBLUJ0yYZmzmt+9i8qL8KFQ/PPDe5cXOCr1Aq2NTSixe5F2K/EI00q6D7QMpBDC7K6zDWgAOvINzifZ0DTkxVe4EE6F+FneDrcJsj+ZeIabrlRcfxtiFziH6unnXktta0sB1xcszIxXdMDbUcJA==",
                 "encryptedValue": "KGfmdUWy89BwhQChzqZJ4w==",
                 "oaepHashingAlgo": "SHA256"
             }
-        }, headers=test_headers)
+        }, headers=test_headers))
 
         self.assertNotIn("encryptedData", decrypted)
         self.assertDictEqual({"data": {}}, decrypted)
@@ -112,11 +112,11 @@ class ApiEncryptionTest(unittest.TestCase):
                         }
 
         api_encryption = to_test.ApiEncryption(self._json_config)
-        decrypted = api_encryption._decrypt_payload(body={
+        decrypted = json.loads(api_encryption._decrypt_payload(body={
             "encryptedData": {
                 "encryptedValue": "KGfmdUWy89BwhQChzqZJ4w=="
             }
-        }, headers=test_headers)
+        }, headers=test_headers))
 
         self.assertNotIn("encryptedData", decrypted)
         self.assertDictEqual({"data": {}}, decrypted)
@@ -170,9 +170,10 @@ class ApiEncryptionTest(unittest.TestCase):
             }
         }, headers={"Content-Type": "application/json"})
 
-        self.assertIn("data", response)
-        self.assertIn("secret", response["data"])
-        self.assertEqual(secret2-secret1, response["data"]["secret"])
+        self.assertIn("data", response.data)
+        self.assertIn("secret", response.data["data"])
+        self.assertEqual(secret2-secret1, response.data["data"]["secret"])
+        self.assertDictEqual({"Content-Type": "application/json"}, response.getheaders())
 
     def test_add_encryption_layer_delete(self):
         secret1 = 394
@@ -186,16 +187,18 @@ class ApiEncryptionTest(unittest.TestCase):
             }
         }, headers={"Content-Type": "application/json"})
 
-        self.assertEqual("OK", response)
+        self.assertEqual("OK", response.data)
+        self.assertDictEqual({"Content-Type": "application/json"}, response.getheaders())
 
     def test_add_encryption_layer_get(self):
         test_client = MockApiClient()
         to_test.add_encryption_layer(test_client, self._json_config)
         response = MockService(test_client).do_something_get(headers={"Content-Type": "application/json"})
 
-        self.assertIn("data", response)
-        self.assertIn("secret", response["data"])
-        self.assertEqual([53, 84, 75], response["data"]["secret"])
+        self.assertIn("data", response.data)
+        self.assertIn("secret", response.data["data"])
+        self.assertEqual([53, 84, 75], response.data["data"]["secret"])
+        self.assertDictEqual({"Content-Type": "application/json"}, response.getheaders())
 
     def test_add_header_encryption_layer_post_no_oaep_algo(self):
         self._set_header_params_config()
@@ -213,9 +216,10 @@ class ApiEncryptionTest(unittest.TestCase):
             "encryptedData": {}
         }, headers={"Content-Type": "application/json"})
 
-        self.assertIn("data", response)
-        self.assertIn("secret", response["data"])
-        self.assertEqual(secret2-secret1, response["data"]["secret"])
+        self.assertIn("data", response.data)
+        self.assertIn("secret", response.data["data"])
+        self.assertEqual(secret2-secret1, response.data["data"]["secret"])
+        self.assertDictEqual({"Content-Type": "application/json", "x-oaep-digest": "SHA256"}, response.getheaders())
 
     def test_add_header_encryption_layer_post_no_cert_fingerprint(self):
         self._set_header_params_config()
@@ -233,9 +237,10 @@ class ApiEncryptionTest(unittest.TestCase):
             "encryptedData": {}
         }, headers={"Content-Type": "application/json"})
 
-        self.assertIn("data", response)
-        self.assertIn("secret", response["data"])
-        self.assertEqual(secret2-secret1, response["data"]["secret"])
+        self.assertIn("data", response.data)
+        self.assertIn("secret", response.data["data"])
+        self.assertEqual(secret2-secret1, response.data["data"]["secret"])
+        self.assertDictEqual({"Content-Type": "application/json"}, response.getheaders())
 
     def test_add_header_encryption_layer_post_no_pubkey_fingerprint(self):
         self._set_header_params_config()
@@ -253,9 +258,10 @@ class ApiEncryptionTest(unittest.TestCase):
             "encryptedData": {}
         }, headers={"Content-Type": "application/json"})
 
-        self.assertIn("data", response)
-        self.assertIn("secret", response["data"])
-        self.assertEqual(secret2-secret1, response["data"]["secret"])
+        self.assertIn("data", response.data)
+        self.assertIn("secret", response.data["data"])
+        self.assertEqual(secret2-secret1, response.data["data"]["secret"])
+        self.assertDictEqual({"Content-Type": "application/json"}, response.getheaders())
 
     def test_add_header_encryption_layer_no_iv(self):
         self._set_header_params_config()
@@ -288,9 +294,10 @@ class ApiEncryptionTest(unittest.TestCase):
             "encryptedData": {}
         }, headers={"Content-Type": "application/json"})
 
-        self.assertIn("data", response)
-        self.assertIn("secret", response["data"])
-        self.assertEqual(secret2-secret1, response["data"]["secret"])
+        self.assertIn("data", response.data)
+        self.assertIn("secret", response.data["data"])
+        self.assertEqual(secret2-secret1, response.data["data"]["secret"])
+        self.assertDictEqual({"Content-Type": "application/json"}, response.getheaders())
 
     def test_add_header_encryption_layer_delete(self):
         self._set_header_params_config()
@@ -307,7 +314,8 @@ class ApiEncryptionTest(unittest.TestCase):
             "encryptedData": {}
         }, headers={"Content-Type": "application/json"})
 
-        self.assertEqual("OK", response)
+        self.assertEqual("OK", response.data)
+        self.assertDictEqual({"Content-Type": "application/json"}, response.getheaders())
 
     def test_add_header_encryption_layer_get(self):
         self._set_header_params_config()
@@ -316,9 +324,10 @@ class ApiEncryptionTest(unittest.TestCase):
         to_test.add_encryption_layer(test_client, self._json_config)
         response = MockService(test_client).do_something_get_use_headers(headers={"Content-Type": "application/json"})
 
-        self.assertIn("data", response)
-        self.assertIn("secret", response["data"])
-        self.assertEqual([53, 84, 75], response["data"]["secret"])
+        self.assertIn("data", response.data)
+        self.assertIn("secret", response.data["data"])
+        self.assertEqual([53, 84, 75], response.data["data"]["secret"])
+        self.assertDictEqual({"Content-Type": "application/json"}, response.getheaders())
 
     @patch('client_encryption.api_encryption.__oauth_warn')
     def test_add_encryption_layer_oauth_set(self, __oauth_warn):

--- a/tests/test_encryption_utils.py
+++ b/tests/test_encryption_utils.py
@@ -131,6 +131,30 @@ class EncryptionUtilsTest(unittest.TestCase):
     def test_load_hash_algorithm_none(self):
         self.assertRaises(HashAlgorithmError, to_test.load_hash_algorithm, None)
 
+    def test_validate_hash_algorithm(self):
+        hash_algo = to_test.validate_hash_algorithm("SHA224")
+
+        self.assertEqual(hash_algo, "SHA224")
+
+    def test_validate_hash_algorithm_dash(self):
+        hash_algo = to_test.validate_hash_algorithm("SHA-512")
+
+        self.assertEqual(hash_algo, "SHA512")
+
+    def test_validate_hash_algorithm_lowercase(self):
+        hash_algo = to_test.validate_hash_algorithm("sha384")
+
+        self.assertEqual(hash_algo, "SHA384")
+
+    def test_validate_hash_algorithm_not_supported(self):
+        self.assertRaises(HashAlgorithmError, to_test.validate_hash_algorithm, "MD5")
+
+    def test_validate_hash_algorithm_underscore(self):
+        self.assertRaises(HashAlgorithmError, to_test.validate_hash_algorithm, "SHA_512")
+
+    def test_validate_hash_algorithm_none(self):
+        self.assertRaises(HashAlgorithmError, to_test.validate_hash_algorithm, None)
+
     @staticmethod
     def __strip_key(rsa_key):
         return rsa_key.export_key(pkcs=8).decode('utf-8').replace("\n", "")[27:-25]

--- a/tests/test_field_level_encryption_config.py
+++ b/tests/test_field_level_encryption_config.py
@@ -151,7 +151,7 @@ class FieldLevelEncryptionConfigTest(unittest.TestCase):
         json_conf["oaepPaddingDigestAlgorithm"] = oaep_algo_test
 
         conf = to_test.FieldLevelEncryptionConfig(json_conf)
-        self.__check_configuration(conf, oaep_algo=oaep_algo_test)
+        self.__check_configuration(conf, oaep_algo="SHA512")
 
     def test_load_config_wrong_oaep_padding_algorithm(self):
         oaep_algo_test = "sha_512"

--- a/tests/utils/api_encryption_test_utils.py
+++ b/tests/utils/api_encryption_test_utils.py
@@ -25,22 +25,22 @@ class MockService(object):
         self.api_client = api_client
 
     def do_something_get(self, **kwargs):
-        return self.api_client.request("GET", "localhost/testservice", headers=kwargs["headers"])
+        return self.api_client.call_api("testservice", "GET", header_params=kwargs["headers"])
 
     def do_something_post(self, **kwargs):
-        return self.api_client.request("POST", "localhost/testservice", headers=kwargs["headers"], body=kwargs["body"])
+        return self.api_client.call_api("testservice", "POST", header_params=kwargs["headers"], body=kwargs["body"])
 
     def do_something_delete(self, **kwargs):
-        return self.api_client.request("DELETE", "localhost/testservice", headers=kwargs["headers"], body=kwargs["body"])
+        return self.api_client.call_api("testservice", "DELETE", header_params=kwargs["headers"], body=kwargs["body"])
 
     def do_something_get_use_headers(self, **kwargs):
-        return self.api_client.request("GET", "localhost/testservice/headers", headers=kwargs["headers"])
+        return self.api_client.call_api("testservice/headers", "GET", header_params=kwargs["headers"])
 
     def do_something_post_use_headers(self, **kwargs):
-        return self.api_client.request("POST", "localhost/testservice/headers", headers=kwargs["headers"], body=kwargs["body"])
+        return self.api_client.call_api("testservice/headers", "POST", header_params=kwargs["headers"], body=kwargs["body"])
 
     def do_something_delete_use_headers(self, **kwargs):
-        return self.api_client.request("DELETE", "localhost/testservice/headers", headers=kwargs["headers"], body=kwargs["body"])
+        return self.api_client.call_api("testservice/headers", "DELETE", header_params=kwargs["headers"], body=kwargs["body"])
 
 
 class MockApiClient(object):
@@ -56,13 +56,21 @@ class MockApiClient(object):
     def request(self, method, url, query_params=None, headers=None,
                 post_params=None, body=None, _preload_content=True,
                 _request_timeout=None):
+        pass
+
+    def call_api(self, resource_path, method,
+                 path_params=None, query_params=None, header_params=None,
+                 body=None, post_params=None, files=None,
+                 response_type=None, auth_settings=None, async_req=None,
+                 _return_http_data_only=None, collection_formats=None,
+                 _preload_content=True, _request_timeout=None):
         check = -1
 
         if body:
-            if url == "localhost/testservice/headers":
-                iv = headers["x-iv"]
-                encrypted_key = headers["x-key"]
-                oaep_digest_algo = headers["x-oaep-digest"] if "x-oaep-digest" in headers else None
+            if resource_path == "testservice/headers":
+                iv = header_params["x-iv"]
+                encrypted_key = header_params["x-key"]
+                oaep_digest_algo = header_params["x-oaep-digest"] if "x-oaep-digest" in header_params else None
 
                 params = SessionKeyParams(self._config, encrypted_key, iv, oaep_digest_algo)
             else:
@@ -74,7 +82,7 @@ class MockApiClient(object):
         else:
             res = {"data": {"secret": [53, 84, 75]}}
 
-        if url == "localhost/testservice/headers" and method in ["GET", "POST", "PUT"]:
+        if resource_path == "testservice/headers" and method in ["GET", "POST", "PUT"]:
             params = SessionKeyParams.generate(self._config)
             json_resp = encryption.encrypt_payload(res, self._config, params)
 

--- a/tests/utils/api_encryption_test_utils.py
+++ b/tests/utils/api_encryption_test_utils.py
@@ -102,7 +102,6 @@ class MockApiClient(object):
 
         if method in ["GET", "POST", "PUT"]:
             response.data = json_resp
-            response.json = Mock(return_value=json_resp)
         else:
             response.data = "OK" if check == 0 else "KO"
 


### PR DESCRIPTION
Change decorator target to call_api function in order to handle '_preload_content' flag and prevent swagger api client from restoring original encrypted fields