### PR TITLE
Node cleanup issue

### DIFF
--- a/client_encryption/field_level_encryption.py
+++ b/client_encryption/field_level_encryption.py
@@ -71,7 +71,7 @@ def decrypt_payload(payload, config, _params=None):
                 else:
                     params = _params
 
-                cleanup_node(json_payload, elem)
+                cleanup_node(json_payload, elem, target)
 
                 try:
                     update_node(json_payload, target, _decrypt_bytes(params.key, params.iv_spec, cipher_text))

--- a/client_encryption/json_path_utils.py
+++ b/client_encryption/json_path_utils.py
@@ -69,19 +69,20 @@ def pop_node(tree, path):
         return node
 
 
-def cleanup_node(tree, path):
-    """Remove a node if no child is found give a path"""
+def cleanup_node(tree, path, target):
+    """Remove a node if not in target path and no child is found given a path"""
 
     if path and __not_root(path):
-        parent = path.split(_SEPARATOR)
-        to_delete = parent.pop()
-        if parent:
-            node = __get_node(tree, parent, False)
-        else:
-            node = tree
+        if not (target and target.startswith(path)):
+            parent = path.split(_SEPARATOR)
+            to_delete = parent.pop()
+            if parent:
+                node = __get_node(tree, parent, False)
+            else:
+                node = tree
 
-        if not node[to_delete]:
-            del node[to_delete]
+            if not node[to_delete]:
+                del node[to_delete]
 
     elif not path:
         raise ValueError("Cannot accept empty path")

--- a/tests/test_json_path_utils.py
+++ b/tests/test_json_path_utils.py
@@ -206,7 +206,7 @@ class JsonPathUtilsTest(unittest.TestCase):
         original_json = self.__get_sample_json()
 
         sample_json = self.__get_sample_json()
-        node = to_test.cleanup_node(sample_json, "node1.node2.colour")
+        node = to_test.cleanup_node(sample_json, "node1.node2.colour", "target")
         self.assertIsInstance(node, dict, "Not a dictionary")
         self.assertDictEqual(original_json, node)
         self.assertDictEqual(original_json, sample_json)
@@ -215,20 +215,49 @@ class JsonPathUtilsTest(unittest.TestCase):
         del sample_json["node1"]["node2"]["colour"]
         del sample_json["node1"]["node2"]["shape"]
         del sample_json["node1"]["node2"]["position"]
-        node = to_test.cleanup_node(sample_json, "node1.node2")
+        node = to_test.cleanup_node(sample_json, "node1.node2", "target")
         self.assertIsInstance(node, dict, "Not a dictionary")
         self.assertDictEqual({"node1": {}}, node)
         self.assertDictEqual({"node1": {}}, sample_json)
 
+    def test_cleanup_node_in_target(self):
+        sample_json = self.__get_sample_json()
+        del sample_json["node1"]["node2"]["colour"]
+        del sample_json["node1"]["node2"]["shape"]
+        del sample_json["node1"]["node2"]["position"]
+        node = to_test.cleanup_node(sample_json, "node1.node2", "node1.node2.target")
+        self.assertIsInstance(node, dict, "Not a dictionary")
+        self.assertDictEqual({"node1": {"node2": {}}}, node)
+        self.assertDictEqual({"node1": {"node2": {}}}, sample_json)
+
     def test_cleanup_node_empty_path(self):
         sample_json = self.__get_sample_json()
-        self.assertRaises(ValueError, to_test.cleanup_node, sample_json, None)
+        self.assertRaises(ValueError, to_test.cleanup_node, sample_json, None, "target")
 
         sample_json = self.__get_sample_json()
-        self.assertRaises(ValueError, to_test.cleanup_node, sample_json, "")
+        self.assertRaises(ValueError, to_test.cleanup_node, sample_json, "", "target")
+
+    def test_cleanup_node_empty_target(self):
+        sample_json = self.__get_sample_json()
+        del sample_json["node1"]["node2"]["colour"]
+        del sample_json["node1"]["node2"]["shape"]
+        del sample_json["node1"]["node2"]["position"]
+        node = to_test.cleanup_node(sample_json, "node1.node2", None)
+        self.assertIsInstance(node, dict, "Not a dictionary")
+        self.assertDictEqual({"node1": {}}, node)
+        self.assertDictEqual({"node1": {}}, sample_json)
+
+        sample_json = self.__get_sample_json()
+        del sample_json["node1"]["node2"]["colour"]
+        del sample_json["node1"]["node2"]["shape"]
+        del sample_json["node1"]["node2"]["position"]
+        node = to_test.cleanup_node(sample_json, "node1.node2", "")
+        self.assertIsInstance(node, dict, "Not a dictionary")
+        self.assertDictEqual({"node1": {}}, node)
+        self.assertDictEqual({"node1": {}}, sample_json)
 
     def test_cleanup_node_not_existing(self):
         sample_json = self.__get_sample_json()
 
-        self.assertRaises(KeyError, to_test.pop_node, sample_json, "node0")
-        self.assertRaises(KeyError, to_test.pop_node, sample_json, "node1.node2.node3")
+        self.assertRaises(KeyError, to_test.cleanup_node, sample_json, "node0", "target")
+        self.assertRaises(KeyError, to_test.cleanup_node, sample_json, "node1.node2.node3", "target")


### PR DESCRIPTION
If the target decrypted node is contained in the given encrypted node for cleanup, then there is no need to delete the encrypted node.