### PR TITLE
Fixing build issue due to pyOpenSSL

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -3,7 +3,7 @@ name: Sonar
   push:
     branches:
       - "**"
-  pull_request_target:
+  pull_request:
     branches:
       - "**"
     types: [opened, synchronize, reopened, labeled]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pycryptodome==3.8.1
-pyOpenSSL>=22.1.0
+pyOpenSSL>=22.1.0,<=23.2.0
 setuptools>=39.0.1
 coverage>=4.5.3
 cryptography>=39.0.0

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,5 @@ setup(name='mastercard-client-encryption',
           'Topic :: Software Development :: Libraries :: Python Modules'
       ],
       tests_require=['coverage'],
-      install_requires=['pycryptodome>=3.8.1', 'pyOpenSSL>=22.0.0', 'setuptools>=39.0.1', 'cryptography>=38.0.0']
+      install_requires=['pycryptodome>=3.8.1', 'pyOpenSSL>=22.0.0,<=23.2.0', 'setuptools>=39.0.1', 'cryptography>=38.0.0']
       )


### PR DESCRIPTION
### PR checklist

- [x] An issue/feature request has been created for this PR
- [x] Pull Request title clearly describes the work in the pull request and the Pull Request description provides details about how to validate the work. Missing information here may result in a delayed response.
- [x] File the PR against the `master` branch
- [x] The code in this PR is covered by unit tests

#### Link to issue/feature request: *add the link here*

#### Description
Fix for the build issue:
AttributeError: module 'OpenSSL.crypto' has no attribute 'load_pkcs12'

The latest version of pyOpenSSL - version 23.3.0 (2023-10-25) has removed support for OpenSSL.crypto.load_pkcs12, which is causing this build issue.
As a quick fix, restricting pyOpenSSL version to the previous version 23.2.0 for which this oauth signer library works.

Refer: 23.3.0 (2023-10-25) https://pypi.org/project/pyOpenSSL/
https://github.com/pyca/pyopenssl/pull/1223/files
