### PR TITLE
Releasing 1.22.1

### DIFF
--- a/client_encryption/version.py
+++ b/client_encryption/version.py
@@ -1,3 +1,3 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-__version__ = "1.22.0"
+__version__ = "1.22.1"


### PR DESCRIPTION
# Description

Adding support for the OpenAPI Generator 7+
The OpenAPI Generator has dropped support for the 'python' library and replaced it with 'python-nextgen'. Release notes can be found [here](https://github.com/OpenAPITools/openapi-generator/releases/tag/v7.0.0)
We must update our interceptor to account for this change.

**NOTE This will break backwards compatibility**